### PR TITLE
Changed directory format of build and obj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .DS_STORE
 .vscode/
-/obj
-/build
+obj/
+build/
 *.o


### PR DESCRIPTION
Updated the `.gitignore` file by changing the format of the `build` and `obj` directories from `/build` and `/obj` to `build/` and `obj/` respectively. Updated to main consistency with other dir names in the .gitignore entries. No technical changes were made to the source code or its working.