### PR TITLE
Updated the entire PersonTest and run_test module to integrate new format of testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 obj/
 build/
 *.o
+PersonTest

--- a/Makefile
+++ b/Makefile
@@ -6,17 +6,21 @@ CPPFLAGS = -Wall -Wextra -Werror
 
 # Source Code Files
 FILES_Person = Person.cpp Person.h
+FILES_run_test = run_test.cpp run_test.h
 
 # Unit test files
-TEST_Person = PersonTest.cpp Person.o
+TEST_Person = PersonTest.cpp Person.o run_test.o
 
 # Custom path to search directories
 vpath %.cpp src/ tests/ util/
-vpath %.h include/
+vpath %.h include/ util/
 
 PersonTest: $(TEST_Person)
 	g++ $(CPPVERSION) $(CPPFLAGS) -c $<
-	g++ Person.o PersonTest.o -o $@
+	g++ Person.o run_test.o PersonTest.o -o $@
+
+run_test.o: $(FILES_run_test)
+	g++ $(CPPVERSION) $(CPPFLAGS) -c $<
 
 Person.o: $(FILES_Person)
 	g++ $(CPPVERSION) $(CPPFLAGS) -c $<

--- a/tests/PersonTest.cpp
+++ b/tests/PersonTest.cpp
@@ -1,33 +1,10 @@
 #include <iostream>
 #include "./../include/Person.h"
+#include "./../util/run_test.h"
 
 using std::cout;
 using std::endl;
 using std::string;
-
-/**
- * Compares the given values and displays the according message.
- * Tests only for strings values
- * @param expected The user-expected value
- * @param result The value returned from the function/method
- * @param method The name of the method/function with the class name.
- */
-void run_test(string expected, string result, string method = "(Method not available)")
-{
-	if (expected != result)
-	{
-		cout << "TEST FAILED!" << endl;
-		cout << "Expected: " << expected << ". Result: " << result << endl;
-		cout << "Bug detected in" << method << " method" << endl;
-	}
-	else
-	{
-		cout << "TEST PASSED!" << endl;
-	}
-}
-
-// void run_test(int expected, int result, string method = "(Method not available)") {}
-
 int main()
 {
 	string expected = "", result = "";
@@ -38,27 +15,27 @@ int main()
 	// TEST 1
 	expected = "Harry";
 	result = person.get_name();
-	run_test(expected, result, "Person.get_name()");
+	run_test(expected, result);
 
 	// TEST 2
 	expected = "abc123";
 	result = person.get_social_insurance_number();
-	run_test(expected, result, "Person.get_social_insurance_number()");
+	run_test(expected, result);
 
 	// TEST 3
 	person.set_name("Ron");
 	expected = "Ron";
 	result = person.get_name();
-	run_test(expected, result, "Person.set_name()");
+	run_test(expected, result);
 
 	// TEST 4
 	person.set_social_insurance_number("ron100");
 	expected = "ron100";
 	result = person.get_social_insurance_number();
-	run_test(expected, result, "Person.set_social_insurance_number()");
+	run_test(expected, result);
 
 	// TEST 5
 	expected = "Name: Ron\nSocial Insurance Number: ron100\n";
 	result = person.to_string();
-	run_test(expected, result, "Person.to_string()");
+	run_test(expected, result);
 }

--- a/util/run_test.cpp
+++ b/util/run_test.cpp
@@ -8,13 +8,12 @@
  * @param result The value returned from the function/method (string)
  * @param method The name of the method/function with the class name. (string)
  */
-void run_test(std::string expected, std::string result, std::string method = "(Method not available)")
+void run_test(std::string expected, std::string result)
 {
 	if (expected != result)
 	{
 		std::cout << "TEST FAILED!" << std::endl;
 		std::cout << "Expected: " << expected << ". Result: " << result << std::endl;
-		std::cout << "Bug detected in" << method << " method" << std::endl;
 	}
 	else
 	{
@@ -29,13 +28,12 @@ void run_test(std::string expected, std::string result, std::string method = "(M
  * @param result The value returned from the function/method (integer)
  * @param method The name of the method/function with the class name. (string)
  */
-void run_test(int expected, int result, std::string method = "(Method not available)")
+void run_test(int expected, int result)
 {
 	if (expected != result)
 	{
 		std::cout << "TEST FAILED!" << std::endl;
 		std::cout << "Expected: " << expected << ". Result: " << result << std::endl;
-		std::cout << "Bug detected in" << method << " method" << std::endl;
 	}
 	else
 	{
@@ -50,13 +48,12 @@ void run_test(int expected, int result, std::string method = "(Method not availa
  * @param result The value returned from the function/method (boolean)
  * @param method The name of the method/function with the class name. (string)
  */
-void run_test(bool expected, bool result, std::string method = "(Method not available)")
+void run_test(bool expected, bool result)
 {
 	if (expected != result)
 	{
 		std::cout << "TEST FAILED!" << std::endl;
 		std::cout << "Expected: " << expected << ". Result: " << result << std::endl;
-		std::cout << "Bug detected in" << method << " method" << std::endl;
 	}
 	else
 	{
@@ -71,7 +68,7 @@ void run_test(bool expected, bool result, std::string method = "(Method not avai
  * @param result The value returned from the function/method (double/float)
  * @param method The name of the method/function with the class name. (string)
  */
-void run_test(bool expected, bool result, std::string method = "(Method not available)")
+void run_test(double expected, double result)
 {
 	double diff = 0.01;
 	double greater = (expected >= result) ? expected : result;
@@ -80,7 +77,6 @@ void run_test(bool expected, bool result, std::string method = "(Method not avai
 	{
 		std::cout << "TEST FAILED!" << std::endl;
 		std::cout << "Expected: " << expected << ". Result: " << result << std::endl;
-		std::cout << "Bug detected in" << method << " method" << std::endl;
 	}
 	else
 	{

--- a/util/run_test.h
+++ b/util/run_test.h
@@ -4,15 +4,15 @@
 #define __RUN_TEST_H__
 
 /** Tests two strings to check if the test was successful or not */
-void run_test(std::string expected, std::string result, std::string method = "(Method not available)");
+void run_test(std::string expected, std::string result);
 
 /** Tests two integers to check if the test was successful or not */
-void run_test(int expected, int result, std::string method = "(Method not available)");
+void run_test(int expected, int result);
 
 /** Tests two booleans to check if the test was successful or not */
-void run_test(bool expected, bool result, std::string method = "(Method not available)");
+void run_test(bool expected, bool result);
 
 /** Tests two floating values to check if the test was successful or not */
-void run_test(double expected, double result, std::string method = "(Method not available)");
+void run_test(double expected, double result);
 
 #endif


### PR DESCRIPTION
- Removed the `std::string method` parameter from each of the `run_test` methods. Due to linker errors.
- Removed the `std::string method` argument passed in the `PersonTest.cpp` file for testing the `Person` module.
- Updated the Makefile to the recent format of testing.
- Added `PersonTest` executable file to `.gitignore` file.